### PR TITLE
feat(vue): added duration prop to Reveal [SIG-351]

### DIFF
--- a/packages/logging-ui/package.json
+++ b/packages/logging-ui/package.json
@@ -15,14 +15,15 @@
         "@nzyme/vue-utils": "0.14.0",
         "@primevue/nuxt-module": "4.5.4",
         "@primevue/themes": "4.5.4",
+        "crossws": "0.3.5",
         "dexie": "4.3.0",
         "lucide-vue-next": "1.0.0",
         "nuxt": "4.4.2",
         "primeicons": "7.0.0",
         "primevue": "4.5.4",
-        "crossws": "0.4.4",
         "vue": "3.5.30",
-        "vue-json-pretty": "2.6.0"
+        "vue-json-pretty": "2.6.0",
+        "vue-router": "^5.0.4"
     },
     "devDependencies": {
         "@nzyme/eslint": "0.14.0",

--- a/packages/vue/src/components/Reveal.module.scss
+++ b/packages/vue/src/components/Reveal.module.scss
@@ -1,5 +1,5 @@
 .reveal {
-    transition: height 0.2s ease-out;
+    transition: height var(--reveal-duration, 0.2s) ease-out;
     display: flex;
     flex-direction: column;
     box-sizing: content-box !important;
@@ -23,8 +23,8 @@
 
 .enterActive {
     transition:
-        opacity 0.2s ease-out 0.1s,
-        transform 0.2s ease-out 0.1s;
+        opacity var(--reveal-duration, 0.2s) ease-out calc(var(--reveal-duration, 0.2s) * 0.5),
+        transform var(--reveal-duration, 0.2s) ease-out calc(var(--reveal-duration, 0.2s) * 0.5);
     opacity: 1;
 }
 
@@ -38,7 +38,7 @@
     top: 0;
     left: 0;
     right: 0;
-    transition: opacity 0.3s ease-out;
+    transition: opacity calc(var(--reveal-duration, 0.2s) * 1.5) ease-out;
     opacity: 0;
 }
 

--- a/packages/vue/src/components/Reveal.test.ts
+++ b/packages/vue/src/components/Reveal.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+
+/**
+ * Tests for the Reveal component's duration style computation.
+ * We test the expression logic directly since mounting the full component
+ * requires a DOM environment.
+ */
+describe('Reveal duration style', () => {
+    // This mirrors the expression used in Reveal.tsx line 53
+    function computeDurationStyle(duration: number | undefined) {
+        return duration != null ? `${duration}ms` : undefined;
+    }
+
+    test('duration=0 should produce "0ms" (not undefined)', () => {
+        // duration=0 means "instant, no animation"
+        // The truthy check incorrectly treats 0 as falsy
+        expect(computeDurationStyle(0)).toBe('0ms');
+    });
+
+    test('duration=undefined should produce undefined', () => {
+        expect(computeDurationStyle(undefined)).toBeUndefined();
+    });
+
+    test('duration=500 should produce "500ms"', () => {
+        expect(computeDurationStyle(500)).toBe('500ms');
+    });
+});

--- a/packages/vue/src/components/Reveal.tsx
+++ b/packages/vue/src/components/Reveal.tsx
@@ -50,7 +50,7 @@ export const Reveal = defineComponent({
             return (
                 <div
                     class={css.reveal}
-                    style={{ '--reveal-duration': props.duration ? `${props.duration}ms` : undefined } as CSSProperties}
+                    style={{ '--reveal-duration': props.duration != null ? `${props.duration}ms` : undefined } as CSSProperties}
                 >
                     <div class={css.reveal_inner}>
                         <Transition

--- a/packages/vue/src/components/Reveal.tsx
+++ b/packages/vue/src/components/Reveal.tsx
@@ -10,7 +10,7 @@ import {
     Transition,
     withCtx,
 } from 'vue';
-import type { ComponentPublicInstance } from 'vue';
+import type { ComponentPublicInstance, CSSProperties } from 'vue';
 
 import css from './Reveal.module.scss';
 
@@ -21,6 +21,9 @@ const fallbackKey = Symbol('fallback');
  */
 export const Reveal = defineComponent({
     name: 'Reveal',
+    props: {
+        duration: { type: Number },
+    },
     emits: {
         beforeEnter: (vm: ComponentPublicInstance) => vm,
         enter: (vm: ComponentPublicInstance) => vm,
@@ -29,7 +32,7 @@ export const Reveal = defineComponent({
         leave: (vm: ComponentPublicInstance) => vm,
         afterLeave: (vm: ComponentPublicInstance) => vm,
     },
-    setup(_props, ctx) {
+    setup(props, ctx) {
         const element = useElement<HTMLElement>();
         const vm = getCurrentInstance()!.proxy!;
 
@@ -45,7 +48,10 @@ export const Reveal = defineComponent({
             ]);
 
             return (
-                <div class={css.reveal}>
+                <div
+                    class={css.reveal}
+                    style={{ '--reveal-duration': props.duration ? `${props.duration}ms` : undefined } as CSSProperties}
+                >
                     <div class={css.reveal_inner}>
                         <Transition
                             enterActiveClass={css.enterActive}


### PR DESCRIPTION
# [SIG-351] Submodule changes

This PR contains changes to the nzyme submodule.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/component change; main impact is altered Reveal transition timings and a dependency tweak that could affect logging-ui bundling if versions are incompatible.
> 
> **Overview**
> Adds an optional `duration` prop to `Reveal` and wires it through a `--reveal-duration` CSS variable so transition timings can be customized (including supporting `0ms`).
> 
> Updates `Reveal` SCSS transitions to use the variable-based duration calculations and adds a small Bun test to lock in the duration style computation behavior.
> 
> Separately adjusts `@nzyme/logging-ui` dependencies by downgrading `crossws` and adding `vue-router`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 478a93d5dfdd5b97df0805ad3e86ebde94abc4a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->