### PR TITLE
feat(vue-forms): a11y fixes [SIG-363]

### DIFF
--- a/packages/vue-forms/src/components/useCheckbox.tsx
+++ b/packages/vue-forms/src/components/useCheckbox.tsx
@@ -30,7 +30,6 @@ function setupCheckbox() {
         return (
             <button
                 aria-checked={!!field.value}
-                aria-readonly={props.readonly}
                 aria-required={props.required}
                 disabled={props.disabled}
                 name={props.name}

--- a/packages/vue-forms/src/components/useRadio.tsx
+++ b/packages/vue-forms/src/components/useRadio.tsx
@@ -54,7 +54,6 @@ export function useRadio<T extends Primitive = Primitive>(props: RadioProps<T>) 
         return (
             <button
                 aria-checked={selected.value}
-                aria-readonly={readonly.value}
                 aria-required={required.value}
                 disabled={disabled.value}
                 name={props.name}

--- a/packages/vue-forms/src/components/useSelectInput.tsx
+++ b/packages/vue-forms/src/components/useSelectInput.tsx
@@ -31,8 +31,7 @@ function setupSelectInput() {
     const SelectInput: FunctionalComponent = (_, ctx) => {
         return (
             <select
-                aria-label={props.label}
-                aria-readonly={props.readonly}
+                aria-label={props.label || props.placeholder}
                 aria-required={props.required}
                 autocomplete={props.autocomplete}
                 disabled={props.disabled}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -7,6 +7,7 @@ export { LazyHydrate } from './components/LazyHydrate.js';
 //export { default as Reveal } from './components/Reveal.vue';
 export { Reveal } from './components/Reveal.js';
 export * from './Format.js';
+export * from './modal/createModalMock.js';
 export * from './modal/ModalContext.js';
 export * from './modal/ModalHost.js';
 export * from './modal/ModalService.js';

--- a/packages/vue/src/modal/createModalMock.ts
+++ b/packages/vue/src/modal/createModalMock.ts
@@ -1,0 +1,21 @@
+import { reactive } from 'vue';
+
+import type { ModalController } from './ModalTypes.js';
+
+/**
+ * Creates a mock modal controller for use in stories and tests.
+ * The controller is reactive, so `open` can be toggled externally.
+ */
+export function createModalMock<T = void>(): ModalController<T> {
+    const controller = reactive<ModalController<T>>({
+        open: false,
+        done() {
+            controller.open = false;
+        },
+        close() {
+            controller.open = false;
+        },
+    });
+
+    return controller as ModalController<T>;
+}


### PR DESCRIPTION
# [SIG-363] Submodule changes

This PR contains changes to the nzyme submodule.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to accessibility attributes on form controls and a new test/story helper export; no business logic or data handling paths are altered.
> 
> **Overview**
> Updates Vue form components’ accessibility attributes: removes `aria-readonly` from `useCheckbox` and `useRadio`, and makes `useSelectInput` fall back to `placeholder` for `aria-label` (while dropping its `aria-readonly`).
> 
> Adds a new reactive `createModalMock()` helper (exported from `packages/vue/src/index.ts`) to provide a simple `ModalController` mock for stories/tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aaa4adbb257081e2ab33d6e01b3e12be7596247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->