### PR TITLE
feat(utils): added lru cache [SIG-365]

### DIFF
--- a/packages/ioc-testing/src/createTestContainer.ts
+++ b/packages/ioc-testing/src/createTestContainer.ts
@@ -1,20 +1,8 @@
 import { createContainer } from '@nzyme/ioc/Container.js';
 import type { Container } from '@nzyme/ioc/Container.js';
-import type { LoggerObject } from '@nzyme/logging/Logger.js';
-import type { LoggerLevel } from '@nzyme/logging/LoggerLevel.js';
-import { consoleLog, LoggerTransport } from '@nzyme/logging/LoggerTransport.js';
-
-/** A log entry captured during test execution. */
-export interface CapturedLog {
-    /** Name of the logger that produced this entry. */
-    readonly logger: string | undefined;
-    /** Severity level of the log entry. */
-    readonly level: LoggerLevel;
-    /** Log message text. */
-    readonly message: string;
-    /** Optional structured data attached to the log entry. */
-    readonly data?: LoggerObject | null;
-}
+import type { CapturedLog } from '@nzyme/logging/createTestLoggerTransport.js';
+import { createTestLoggerTransport } from '@nzyme/logging/createTestLoggerTransport.js';
+import { LoggerTransport } from '@nzyme/logging/LoggerTransport.js';
 
 /** Result of creating a test container, providing the container and captured logs. */
 export interface TestContainerResult {
@@ -42,18 +30,9 @@ export interface TestContainerResult {
  * ```
  */
 export function createTestContainer(): TestContainerResult {
-    const enabled = process.env.LOGGING === 'true';
-
     const container = createContainer();
-    const logs: CapturedLog[] = [];
+    const { transport, logs } = createTestLoggerTransport();
 
-    const transport: LoggerTransport = (logger, level, message, obj) => {
-        logs.push({ logger, level, message, data: obj });
-
-        if (enabled) {
-            consoleLog(logger, level, message, obj);
-        }
-    };
     container.set(LoggerTransport, transport);
 
     return { container, logs };

--- a/packages/logging/src/createTestLogger.ts
+++ b/packages/logging/src/createTestLogger.ts
@@ -1,0 +1,34 @@
+import type { CapturedLog } from './createTestLoggerTransport.js';
+import { createTestLoggerTransport } from './createTestLoggerTransport.js';
+import type { Logger, LoggerObject } from './Logger.js';
+
+/** Result of creating a test logger, providing the logger and captured logs. */
+export interface TestLoggerResult {
+    /** Logger instance backed by the test transport. */
+    logger: Logger;
+    /** Log entries captured by the underlying transport, in order. */
+    logs: CapturedLog[];
+}
+
+/**
+ * Create a {@link Logger} backed by a test transport. Log entries are captured into the returned
+ * `logs` array and also forwarded to the console when `process.env.LOGGING === 'true'`.
+ *
+ * @param name - Name assigned to the logger and emitted with every entry.
+ *
+ * @__NO_SIDE_EFFECTS__
+ */
+export function createTestLogger(name: string): TestLoggerResult {
+    const { transport, logs } = createTestLoggerTransport();
+
+    const logger: Logger = {
+        name,
+        error: (msg: string, obj?: LoggerObject) => transport(name, 'error', msg, obj),
+        warn: (msg: string, obj?: LoggerObject) => transport(name, 'warn', msg, obj),
+        info: (msg: string, obj?: LoggerObject) => transport(name, 'info', msg, obj),
+        debug: (msg: string, obj?: LoggerObject) => transport(name, 'debug', msg, obj),
+        trace: (msg: string, obj?: LoggerObject) => transport(name, 'trace', msg, obj),
+    };
+
+    return { logger, logs };
+}

--- a/packages/logging/src/createTestLoggerTransport.ts
+++ b/packages/logging/src/createTestLoggerTransport.ts
@@ -1,0 +1,45 @@
+import type { LoggerObject } from './Logger.js';
+import type { LoggerLevel } from './LoggerLevel.js';
+import { consoleLog  } from './LoggerTransport.js';
+import type {LoggerTransport} from './LoggerTransport.js';
+
+/** A log entry captured during test execution. */
+export interface CapturedLog {
+    /** Name of the logger that produced this entry. */
+    readonly logger: string | undefined;
+    /** Severity level of the log entry. */
+    readonly level: LoggerLevel;
+    /** Log message text. */
+    readonly message: string;
+    /** Optional structured data attached to the log entry. */
+    readonly data?: LoggerObject | null;
+}
+
+/** Result of creating a test logger transport. */
+export interface TestLoggerTransportResult {
+    /** Transport that records every log entry into {@link logs}. */
+    transport: LoggerTransport;
+    /** Log entries captured by the transport, in order. */
+    logs: CapturedLog[];
+}
+
+/**
+ * Create a {@link LoggerTransport} suitable for tests — captures every log entry into an array
+ * and, when `process.env.LOGGING === 'true'`, also forwards it to the console for debugging.
+ *
+ * @__NO_SIDE_EFFECTS__
+ */
+export function createTestLoggerTransport(): TestLoggerTransportResult {
+    const enabled = process.env.LOGGING === 'true';
+    const logs: CapturedLog[] = [];
+
+    const transport: LoggerTransport = (logger, level, message, obj) => {
+        logs.push({ logger, level, message, data: obj });
+
+        if (enabled) {
+            consoleLog(logger, level, message, obj);
+        }
+    };
+
+    return { transport, logs };
+}

--- a/packages/logging/src/index.ts
+++ b/packages/logging/src/index.ts
@@ -1,5 +1,7 @@
 export * from './ApplicationError.js';
 export * from './createLogger.js';
+export * from './createTestLogger.js';
+export * from './createTestLoggerTransport.js';
 export * from './createWebsocketLoggerTransport.js';
 export * from './extractErrorData.js';
 export * from './Logger.js';

--- a/packages/utils/src/createLruCache.test.ts
+++ b/packages/utils/src/createLruCache.test.ts
@@ -131,3 +131,36 @@ test('maxSize of 1 keeps only the latest entry', () => {
     expect(lru.get('b')).toBe(2);
     expect(lru.size).toBe(1);
 });
+
+test('get promotes entries with undefined values', () => {
+    const lru = createLruCache<string, number | undefined>({ maxSize: 3 });
+
+    lru.set('a', undefined);
+    lru.set('b', 2);
+    lru.set('c', 3);
+
+    // Access 'a' to make it most recent — even though its value is undefined
+    lru.get('a');
+
+    // 'b' should now be the oldest and get evicted when we add 'd'
+    lru.set('d', 4);
+
+    expect(lru.has('a')).toBe(true);
+    expect(lru.has('b')).toBe(false);
+    expect(lru.has('c')).toBe(true);
+    expect(lru.has('d')).toBe(true);
+    expect(lru.size).toBe(3);
+});
+
+test('evicts oldest entry when oldest key is undefined', () => {
+    const lru = createLruCache<undefined | string, number>({ maxSize: 2 });
+
+    lru.set(undefined, 1);
+    lru.set('b', 2);
+    lru.set('c', 3); // should evict undefined key
+
+    expect(lru.has(undefined)).toBe(false);
+    expect(lru.has('b')).toBe(true);
+    expect(lru.has('c')).toBe(true);
+    expect(lru.size).toBe(2);
+});

--- a/packages/utils/src/createLruCache.test.ts
+++ b/packages/utils/src/createLruCache.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from 'bun:test';
+
+import { createLruCache } from './createLruCache.js';
+
+test('set and get values', () => {
+    const lru = createLruCache<string, number>({ maxSize: 3 });
+
+    lru.set('a', 1);
+    lru.set('b', 2);
+
+    expect(lru.get('a')).toBe(1);
+    expect(lru.get('b')).toBe(2);
+    expect(lru.get('c')).toBeUndefined();
+});
+
+test('evicts oldest entry when at capacity', () => {
+    const lru = createLruCache<string, number>({ maxSize: 3 });
+
+    lru.set('a', 1);
+    lru.set('b', 2);
+    lru.set('c', 3);
+    lru.set('d', 4); // should evict 'a'
+
+    expect(lru.get('a')).toBeUndefined();
+    expect(lru.get('b')).toBe(2);
+    expect(lru.get('d')).toBe(4);
+    expect(lru.size).toBe(3);
+});
+
+test('get moves entry to most recent position', () => {
+    const lru = createLruCache<string, number>({ maxSize: 3 });
+
+    lru.set('a', 1);
+    lru.set('b', 2);
+    lru.set('c', 3);
+
+    // Access 'a' to make it most recent
+    lru.get('a');
+
+    // Now 'b' is oldest — should be evicted
+    lru.set('d', 4);
+
+    expect(lru.get('b')).toBeUndefined();
+    expect(lru.get('a')).toBe(1);
+    expect(lru.size).toBe(3);
+});
+
+test('set with existing key updates value and moves to most recent', () => {
+    const lru = createLruCache<string, number>({ maxSize: 3 });
+
+    lru.set('a', 1);
+    lru.set('b', 2);
+    lru.set('c', 3);
+
+    // Update 'a' — should move to most recent
+    lru.set('a', 10);
+
+    // Now 'b' is oldest
+    lru.set('d', 4);
+
+    expect(lru.get('b')).toBeUndefined();
+    expect(lru.get('a')).toBe(10);
+    expect(lru.size).toBe(3);
+});
+
+test('has returns correct boolean', () => {
+    const lru = createLruCache<string, number>({ maxSize: 3 });
+
+    lru.set('a', 1);
+
+    expect(lru.has('a')).toBe(true);
+    expect(lru.has('b')).toBe(false);
+});
+
+test('delete removes entry and returns boolean', () => {
+    const lru = createLruCache<string, number>({ maxSize: 3 });
+
+    lru.set('a', 1);
+    lru.set('b', 2);
+
+    expect(lru.delete('a')).toBe(true);
+    expect(lru.delete('a')).toBe(false);
+    expect(lru.get('a')).toBeUndefined();
+    expect(lru.size).toBe(1);
+});
+
+test('clear removes all entries', () => {
+    const lru = createLruCache<string, number>({ maxSize: 3 });
+
+    lru.set('a', 1);
+    lru.set('b', 2);
+    lru.set('c', 3);
+
+    lru.clear();
+
+    expect(lru.size).toBe(0);
+    expect(lru.get('a')).toBeUndefined();
+});
+
+test('keys and values iterate in insertion order', () => {
+    const lru = createLruCache<string, number>({ maxSize: 5 });
+
+    lru.set('a', 1);
+    lru.set('b', 2);
+    lru.set('c', 3);
+
+    expect([...lru.keys()]).toEqual(['a', 'b', 'c']);
+    expect([...lru.values()]).toEqual([1, 2, 3]);
+});
+
+test('custom map is used as backing store', () => {
+    const backingMap = new Map<string, number>();
+    const lru = createLruCache<string, number>({ maxSize: 3, cache: backingMap });
+
+    lru.set('a', 1);
+    lru.set('b', 2);
+
+    // Backing map should contain the entries
+    expect(backingMap.get('a')).toBe(1);
+    expect(backingMap.get('b')).toBe(2);
+    expect(lru.cache).toBe(backingMap);
+});
+
+test('maxSize of 1 keeps only the latest entry', () => {
+    const lru = createLruCache<string, number>({ maxSize: 1 });
+
+    lru.set('a', 1);
+    lru.set('b', 2);
+
+    expect(lru.get('a')).toBeUndefined();
+    expect(lru.get('b')).toBe(2);
+    expect(lru.size).toBe(1);
+});

--- a/packages/utils/src/createLruCache.ts
+++ b/packages/utils/src/createLruCache.ts
@@ -64,12 +64,13 @@ export function createLruCache<K, V>(options: CreateLruCacheOptions<K, V>): LruC
     };
 
     function get(key: K): V | undefined {
-        const value = cache.get(key);
-        if (value !== undefined) {
-            // Move to most recent by re-inserting
-            cache.delete(key);
-            cache.set(key, value);
+        if (!cache.has(key)) {
+            return undefined;
         }
+        const value = cache.get(key);
+        // Move to most recent by re-inserting
+        cache.delete(key);
+        cache.set(key, value as V);
         return value;
     }
 
@@ -78,10 +79,11 @@ export function createLruCache<K, V>(options: CreateLruCacheOptions<K, V>): LruC
         cache.delete(key);
 
         if (cache.size >= maxSize) {
-            // Evict the oldest (first) entry
-            const oldest = cache.keys().next().value;
-            if (oldest !== undefined) {
+            // Evict the oldest (first) entry — iterate keys() to handle
+            // cases where `undefined` itself is a valid key.
+            for (const oldest of cache.keys()) {
                 cache.delete(oldest);
+                break;
             }
         }
 

--- a/packages/utils/src/createLruCache.ts
+++ b/packages/utils/src/createLruCache.ts
@@ -1,0 +1,102 @@
+/**
+ * Options for creating an LRU cache.
+ * @template K - The type of the cache keys
+ * @template V - The type of the cached values
+ */
+export interface CreateLruCacheOptions<K, V> {
+    /** Maximum number of entries before the least recently used is evicted. */
+    maxSize: number;
+    /**
+     * Backing map for the cache. Pass `reactive(new Map())` to make the cache reactive in Vue.
+     * Defaults to a plain `Map`.
+     */
+    cache?: Map<K, V>;
+}
+
+/**
+ * An LRU (Least Recently Used) cache that evicts the oldest entry when capacity is exceeded.
+ * @template K - The type of the cache keys
+ * @template V - The type of the cached values
+ */
+export interface LruCache<K, V> {
+    /** Get a value by key. Moves the entry to most-recently-used position. */
+    get(key: K): V | undefined;
+    /** Set a value. Evicts the least recently used entry if at capacity. */
+    set(key: K, value: V): void;
+    /** Check if a key exists without affecting recency. */
+    has(key: K): boolean;
+    /** Delete a key. Returns true if the key existed. */
+    delete(key: K): boolean;
+    /** Remove all entries. */
+    clear(): void;
+    /** Iterate over all values in insertion order (oldest first). */
+    values(): IterableIterator<V>;
+    /** Iterate over all keys in insertion order (oldest first). */
+    keys(): IterableIterator<K>;
+    /** Current number of entries. */
+    readonly size: number;
+    /** The underlying map. */
+    readonly cache: Map<K, V>;
+}
+
+/**
+ * Creates an LRU cache backed by a Map.
+ * Map preserves insertion order — delete+set moves an entry to the end (most recent).
+ *
+ * @__NO_SIDE_EFFECTS__
+ */
+export function createLruCache<K, V>(options: CreateLruCacheOptions<K, V>): LruCache<K, V> {
+    const { maxSize } = options;
+    const cache = options.cache ?? new Map<K, V>();
+
+    return {
+        get,
+        set,
+        has,
+        delete: deleteKey,
+        clear,
+        values: () => cache.values(),
+        keys: () => cache.keys(),
+        get size() {
+            return cache.size;
+        },
+        cache,
+    };
+
+    function get(key: K): V | undefined {
+        const value = cache.get(key);
+        if (value !== undefined) {
+            // Move to most recent by re-inserting
+            cache.delete(key);
+            cache.set(key, value);
+        }
+        return value;
+    }
+
+    function set(key: K, value: V): void {
+        // If key already exists, delete first to update insertion order
+        cache.delete(key);
+
+        if (cache.size >= maxSize) {
+            // Evict the oldest (first) entry
+            const oldest = cache.keys().next().value;
+            if (oldest !== undefined) {
+                cache.delete(oldest);
+            }
+        }
+
+        cache.set(key, value);
+    }
+
+    function has(key: K): boolean {
+        return cache.has(key);
+    }
+
+    function deleteKey(key: K): boolean {
+        return cache.delete(key);
+    }
+
+    function clear(): void {
+        cache.clear();
+    }
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -42,6 +42,7 @@ export * from './createCache.js';
 export * from './createEventEmitter.js';
 export * from './createExponentialBackoff.js';
 export * from './createGetter.js';
+export * from './createLruCache.js';
 export * from './createMemo.js';
 export * from './createNamedFunction.js';
 export * from './createParalellRunner.js';


### PR DESCRIPTION
# [SIG-365] Submodule changes

This PR contains changes to the nzyme submodule.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive utilities and test helpers; the only behavior change is consolidating test log capture/forwarding, which should be low impact outside tests.
> 
> **Overview**
> Adds a new `createLruCache` utility (Map-backed) to `@nzyme/utils`, exports it from the package, and includes a comprehensive Bun test suite covering eviction and recency edge cases.
> 
> Refactors test logging helpers by introducing `createTestLoggerTransport` (and `createTestLogger`) in `@nzyme/logging`, exporting them publicly, and updating `createTestContainer` in `ioc-testing` to use the shared transport instead of duplicating capture/console-forward logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78638c7c5819e7ccf4ce69e8cea13dd3338aa162. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->