### PR TITLE
fix(vue): loading context auto loads after 50ms without async activity [SIG-371]

### DIFF
--- a/packages/vue-utils/src/useLoadingContext.ts
+++ b/packages/vue-utils/src/useLoadingContext.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 
 import { defineContext, injectContext, provideContext } from './context.js';
 import { reactive } from './reactivity/reactive.js';
@@ -204,5 +204,10 @@ export function useLoadingContext(opts: LoadingContextOptions = {}): LoadingCont
     });
 
     provideContext(LoadingContextSymbol, context);
+
+    onMounted(() => {
+        setTimeout(checkLoadedOnce, 50);
+    });
+
     return context;
 }


### PR DESCRIPTION
# [SIG-371] Submodule changes

This PR contains changes to the nzyme submodule.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to a Vue composable’s initialization timing; risk is limited to components depending on `loadedOnce` semantics.
> 
> **Overview**
> Ensures `useLoadingContext` sets `loadedOnce` even when no async work runs by scheduling a post-mount `checkLoadedOnce` call (after 50ms). This adds a Vue `onMounted` hook and updates imports to support the new timing-based initialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71febaa70d10144fe5f0988366efdf84f7a485d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->