### PR TITLE
fix(rpc): take last x-forwarded-for entry (ALB-appended real client IP)

### DIFF
--- a/packages/rpc/src/createMiddleware.ts
+++ b/packages/rpc/src/createMiddleware.ts
@@ -71,13 +71,17 @@ export function createMiddleware(options: CreateMiddlewareOptions): RequestListe
     }
 
     function getIp(req: IncomingMessage) {
+        // Behind a load balancer the trustworthy client IP is the LAST x-forwarded-for entry (the
+        // one the LB appends); the leftmost entries are client-supplied and can be spoofed. If a
+        // second proxy is ever added in front, switch to an explicit trusted-hop count.
         const xForwardedFor = req.headers['x-forwarded-for'];
-        if (Array.isArray(xForwardedFor)) {
-            return xForwardedFor[0];
-        }
-
-        if (xForwardedFor) {
-            return xForwardedFor;
+        const forwardedHeader = Array.isArray(xForwardedFor) ? xForwardedFor[xForwardedFor.length - 1] : xForwardedFor;
+        if (forwardedHeader) {
+            const parts = forwardedHeader.split(',');
+            const last = parts[parts.length - 1]?.trim();
+            if (last) {
+                return last;
+            }
         }
 
         return req.socket.remoteAddress;


### PR DESCRIPTION
## What

`createMiddleware`'s `getIp()` returned the **first** `x-forwarded-for` entry, which is client-controlled and therefore spoofable. Behind a load balancer the trustworthy client IP is the **last** entry (appended by the LB); the leftmost entries are whatever the client put in its own header.

Now takes the last non-empty comma-split entry (and the last element for the array-header form). If a second proxy is ever placed in front of the LB, switch to an explicit trusted-hop count.

## Why

Surfaced during review of SigmaClinic/sigma#64 (SIG-77, HIPAA audit log): the same first-entry pattern in `@sigma/actors-server` let any client spoof the audit `sourceIp`. This fixes the shared nzyme helper that has the same flaw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)