### PR TITLE
[SIG-160] Spread fallthrough attrs onto RouterLink anchor in useButton

### DIFF
--- a/packages/vue-forms/src/components/useButton.ts
+++ b/packages/vue-forms/src/components/useButton.ts
@@ -170,6 +170,10 @@ function setupButton() {
                     return h(
                         'a',
                         {
+                            // Spread fallthrough attrs (e.g. `tid`, aria-*) like the button/external-link
+                            // paths do, so internal links keep the same attributes — `href`/`onClick`
+                            // below intentionally override any incoming values.
+                            ...attrs,
                             href,
                             onClick: (event: Event) => onClick(event, navigate),
                             disabled: disabled.value || undefined,


### PR DESCRIPTION
## Summary

Fixes a bug where `Button` with an internal router `:link` dropped fallthrough attributes (notably `tid`) on the rendered `<a>` element. The `RouterLink` branch of `useButton` was not spreading `attrs` onto the anchor, unlike the native-button and external-link branches.

This surfaced while addressing PR review feedback on SigmaClinic/sigma#83, which asked to migrate team table rows and the "New team" buttons to `:link` navigation. Those buttons carry `tid` attributes that e2e harnesses rely on, and the missing attr-spread would have broken them.

## Change

- `useButton.ts`: spread `attrs` onto the `RouterLink` anchor branch so `tid` (and any other fallthrough attribute) renders on the `<a>`, matching the other branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)