### PR TITLE
feat(linear): Add onTaskSwitched hook to Linear task commands [SIG-288]

### DIFF
--- a/packages/linear/src/cli/TaskSwitchedHook.ts
+++ b/packages/linear/src/cli/TaskSwitchedHook.ts
@@ -1,0 +1,8 @@
+import type { TaskSwitchedInfo } from './TaskSwitchedInfo.js';
+
+/**
+ * Called after the CLI has successfully switched to a task,
+ * so the host project can react to it (e.g. rename its workspace).
+ * Runs for its side effects only - failures never fail the command.
+ */
+export type TaskSwitchedHook = (task: TaskSwitchedInfo) => Promise<void> | void;

--- a/packages/linear/src/cli/TaskSwitchedInfo.ts
+++ b/packages/linear/src/cli/TaskSwitchedInfo.ts
@@ -1,0 +1,21 @@
+import type { Logger } from '@nzyme/logging/Logger.js';
+
+/**
+ * Details of the task the CLI has just switched to.
+ */
+export interface TaskSwitchedInfo {
+    /**
+     * The Linear issue ID (e.g., "SIG-123").
+     */
+    issueId: string;
+
+    /**
+     * The Linear issue title, as stored in Linear.
+     */
+    title: string;
+
+    /**
+     * Logger of the command that performed the switch.
+     */
+    logger: Logger;
+}

--- a/packages/linear/src/cli/defineLinearCommands.ts
+++ b/packages/linear/src/cli/defineLinearCommands.ts
@@ -22,6 +22,7 @@ import { formatProjectStatus } from '../utils/formatProjectStatus.js';
 import { getNonCompleteProjects } from '../utils/getProjects.js';
 import { parseTaskIdentifier } from '../utils/parseTaskIdentifier.js';
 import { switchToTask } from '../utils/switchToTask.js';
+import type { TaskSwitchedHook } from './TaskSwitchedHook.js';
 
 /**
  * Configuration for Linear API access.
@@ -61,6 +62,12 @@ export interface LinearCommandsOptions {
      * The function to call before each command.
      */
     beforeEach?: () => Promise<void>;
+
+    /**
+     * Called after a command has successfully switched to a task.
+     * Failures are logged and never fail the command.
+     */
+    onTaskSwitched?: TaskSwitchedHook;
 
     /**
      * The base branch(es) to use when creating new branches.
@@ -224,6 +231,7 @@ function defineTaskStartCommand(options: LinearCommandsOptions) {
                     logger: this.logger,
                     baseBranches,
                     branch: this.branch,
+                    onTaskSwitched: options.onTaskSwitched,
                 });
             } catch (error) {
                 const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -337,6 +345,7 @@ function defineTaskNewCommand(options: LinearCommandsOptions) {
                     logger: this.logger,
                     baseBranches,
                     branch: this.branch,
+                    onTaskSwitched: options.onTaskSwitched,
                 });
             } catch (error) {
                 const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -826,6 +835,7 @@ function defineTaskListCommand(options: LinearCommandsOptions) {
                     logger: this.logger,
                     baseBranches,
                     branch: this.branch,
+                    onTaskSwitched: options.onTaskSwitched,
                 });
             } catch (error) {
                 const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/packages/linear/src/utils/runTaskSwitchedHook.test.ts
+++ b/packages/linear/src/utils/runTaskSwitchedHook.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from 'bun:test';
+
+import type { Logger, LoggerObject } from '@nzyme/logging/Logger.js';
+
+import type { TaskSwitchedInfo } from '../cli/TaskSwitchedInfo.js';
+import { runTaskSwitchedHook } from './runTaskSwitchedHook.js';
+
+test('calls the hook with the task details', async () => {
+    const calls: TaskSwitchedInfo[] = [];
+    const task = createTask();
+
+    await runTaskSwitchedHook(info => {
+        calls.push(info);
+    }, task);
+
+    expect(calls).toEqual([task]);
+});
+
+test('awaits an asynchronous hook before returning', async () => {
+    let finished = false;
+    const task = createTask();
+
+    await runTaskSwitchedHook(async () => {
+        await Promise.resolve();
+        finished = true;
+    }, task);
+
+    expect(finished).toBe(true);
+});
+
+test('warns instead of throwing when the hook rejects', async () => {
+    const warnings: { msg: string; obj: LoggerObject | undefined }[] = [];
+    const error = new Error('daemon unreachable');
+    const task = createTask({ warn: (msg, obj) => warnings.push({ msg, obj }) });
+
+    await runTaskSwitchedHook(() => Promise.reject(error), task);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.msg).toContain('SIG-123');
+    expect(warnings[0]?.obj).toEqual({ error });
+});
+
+test('warns instead of throwing when the hook throws synchronously', async () => {
+    const warnings: string[] = [];
+    const task = createTask({ warn: msg => warnings.push(msg) });
+
+    await runTaskSwitchedHook(() => {
+        throw new Error('boom');
+    }, task);
+
+    expect(warnings).toHaveLength(1);
+});
+
+test('does nothing when no hook is configured', async () => {
+    const logs: string[] = [];
+    const task = createTask({
+        warn: msg => logs.push(msg),
+        info: msg => logs.push(msg),
+        error: msg => logs.push(msg),
+    });
+
+    await runTaskSwitchedHook(undefined, task);
+
+    expect(logs).toEqual([]);
+});
+
+function createTask(logger?: Partial<Logger>): TaskSwitchedInfo {
+    return {
+        issueId: 'SIG-123',
+        title: 'Some Linear title',
+        logger: {
+            name: 'test',
+            error: () => {},
+            warn: () => {},
+            info: () => {},
+            debug: () => {},
+            trace: () => {},
+            ...logger,
+        },
+    };
+}

--- a/packages/linear/src/utils/runTaskSwitchedHook.ts
+++ b/packages/linear/src/utils/runTaskSwitchedHook.ts
@@ -1,0 +1,19 @@
+import type { TaskSwitchedHook } from '../cli/TaskSwitchedHook.js';
+import type { TaskSwitchedInfo } from '../cli/TaskSwitchedInfo.js';
+
+/**
+ * Run the task-switched hook, if one is configured.
+ * The hook is a side effect of an already completed switch,
+ * so a failing hook only warns and never fails the command.
+ */
+export async function runTaskSwitchedHook(hook: TaskSwitchedHook | undefined, task: TaskSwitchedInfo) {
+    if (!hook) {
+        return;
+    }
+
+    try {
+        await hook(task);
+    } catch (error) {
+        task.logger.warn(`⚠️  Task switched hook failed for ${task.issueId}`, { error });
+    }
+}

--- a/packages/linear/src/utils/switchToTask.ts
+++ b/packages/linear/src/utils/switchToTask.ts
@@ -74,8 +74,7 @@ export interface SwitchToTaskParams {
  * This contains the common logic used by both "task start" and "task new" commands.
  */
 export async function switchToTask(params: SwitchToTaskParams): Promise<void> {
-    const { issueId, linearClient, githubClient, githubConfig, logger, baseBranches, branch, onTaskSwitched } =
-        params;
+    const { issueId, linearClient, githubClient, githubConfig, logger, baseBranches, branch, onTaskSwitched } = params;
 
     logger.info(`🔍 Looking for Linear task: ${chalk.bold(issueId)}`);
 

--- a/packages/linear/src/utils/switchToTask.ts
+++ b/packages/linear/src/utils/switchToTask.ts
@@ -13,9 +13,11 @@ import { handleMergedPrReopen } from '@nzyme/github-cli/utils/handleMergedPrReop
 import { syncBaseBranch } from '@nzyme/github-cli/utils/syncBaseBranch.js';
 import type { Logger } from '@nzyme/logging/Logger.js';
 
+import type { TaskSwitchedHook } from '../cli/TaskSwitchedHook.js';
 import { handleTaskAssignment } from './handleTaskAssignment.js';
 import { handleTerminalState } from './handleTerminalState.js';
 import { reopenLinearTask } from './reopenLinearTask.js';
+import { runTaskSwitchedHook } from './runTaskSwitchedHook.js';
 import { startTaskIfNotStarted } from './startTaskIfNotStarted.js';
 
 /**
@@ -59,6 +61,12 @@ export interface SwitchToTaskParams {
      * from the up-to-date remote tip of this branch instead of the default.
      */
     branch?: string;
+
+    /**
+     * Called after the task has been successfully switched to.
+     * Failures are logged and never fail the switch.
+     */
+    onTaskSwitched?: TaskSwitchedHook;
 }
 
 /**
@@ -66,7 +74,8 @@ export interface SwitchToTaskParams {
  * This contains the common logic used by both "task start" and "task new" commands.
  */
 export async function switchToTask(params: SwitchToTaskParams): Promise<void> {
-    const { issueId, linearClient, githubClient, githubConfig, logger, baseBranches, branch } = params;
+    const { issueId, linearClient, githubClient, githubConfig, logger, baseBranches, branch, onTaskSwitched } =
+        params;
 
     logger.info(`🔍 Looking for Linear task: ${chalk.bold(issueId)}`);
 
@@ -142,6 +151,7 @@ export async function switchToTask(params: SwitchToTaskParams): Promise<void> {
         if (reopenResult.reopened) {
             // Task was reopened with new version - we're done
             logger.info(`🔗 Linear task: ${chalk.underline(issueData.url)}`);
+            await runTaskSwitchedHook(onTaskSwitched, { issueId, title: issueData.title, logger });
             return;
         }
 
@@ -196,6 +206,8 @@ export async function switchToTask(params: SwitchToTaskParams): Promise<void> {
     // Deferred until after checkout/create work has committed so we don't
     // transition the Linear state when the user cancels or a later step throws.
     await startTaskIfNotStarted(issueData, logger);
+
+    await runTaskSwitchedHook(onTaskSwitched, { issueId, title: issueData.title, logger });
 
     // Show task URL for reference
     logger.info(`🔗 Linear task: ${chalk.underline(issueData.url)}`);


### PR DESCRIPTION
# [SIG-288] Submodule changes

This PR contains changes to the nzyme submodule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional post-switch hooks for CLI task commands.
  * Hooks receive the switched task’s issue ID, title, and logger.
  * Hooks run after successful task switches, including reopened tasks.

* **Bug Fixes**
  * Hook errors are logged as warnings without interrupting task commands.
  * Asynchronous hooks are completed before the command continues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->